### PR TITLE
Make rpm template fully reproducible

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,7 @@
       inherit nixpkgs;
       qubesVersion = "4.2.0";
       nixosConfig = nixosConfigurations.nixos;
+      templateTimestamp = builtins.substring 0 12 self.lastModifiedDate;
     };
     iso = nixosConfigurations.iso.config.system.build.isoImage;
     packages.x86_64-linux = pkgs;

--- a/tools/rpm.nix
+++ b/tools/rpm.nix
@@ -5,25 +5,56 @@
   pkgs,
   nixosConfig,
   qubesVersion,
+  templateTimestamp ? "197001010000",
 }: let
   version = "4.0.6";
-  rootImg = import "${nixpkgs}/nixos/lib/make-disk-image.nix" {
-    inherit lib pkgs;
-    config = nixosConfig.config;
-    contents = [
-      {
-        source = ../examples/configuration.nix;
-        target = "/etc/nixos/configuration.nix";
-      }
-      {
-        source = ../examples/flake.nix;
-        target = "/etc/nixos/flake.nix";
-      }
-    ];
-    diskSize = 10240; # 10G
-    partitionTableType = "hybrid";
-    name = "root";
-  };
+  toplevel = nixosConfig.config.system.build.toplevel;
+
+  # See: https://reproducible-builds.org/docs/system-images/
+  e2fsprogs-deterministic =
+    let
+      wrappedMke2fs = pkgs.writeShellScriptBin "mke2fs" ''
+        exec ${pkgs.e2fsprogs.bin}/bin/mke2fs -E hash_seed=035cb65d-0a86-404a-bad7-19c88d05e400 "$@"
+      '';
+      drv = pkgs.symlinkJoin {
+        name = "e2fsprogs-deterministic";
+        paths = [
+          pkgs.e2fsprogs.bin
+          wrappedMke2fs
+        ];
+        postBuild = ''
+          rm -f $out/bin/mkfs.ext4
+          ln -s mke2fs $out/bin/mkfs.ext4
+        '';
+      };
+    in
+    drv // { bin = drv; };
+
+  rootImg = (pkgs.callPackage "${nixpkgs}/nixos/lib/make-ext4-fs.nix" {
+    storePaths = [ toplevel ];
+    volumeLabel = "root";
+    e2fsprogs = e2fsprogs-deterministic;
+    populateImageCommands = ''
+      mkdir -p ./files/nix/var/nix/profiles
+      ln -s ${toplevel} ./files/nix/var/nix/profiles/system-1-link
+      ln -s system-1-link ./files/nix/var/nix/profiles/system
+
+      mkdir -p ./files/sbin
+      ln -s /nix/var/nix/profiles/system/init ./files/sbin/init
+      mkdir -p ./files/etc
+      touch ./files/etc/NIXOS
+      mkdir -p ./files/var
+      ln -s /run ./files/var/run
+
+      mkdir -p ./files/etc/nixos
+      cp ${../examples/configuration.nix} ./files/etc/nixos/configuration.nix
+      cp ${../examples/flake.nix} ./files/etc/nixos/flake.nix
+    '';
+  }).overrideAttrs (prev: {
+    buildCommand = prev.buildCommand + ''
+      truncate -s 10G $img
+    '';
+  });
 in
   pkgs.stdenvNoCC.mkDerivation {
     name = "qubes-template-rpm";
@@ -48,17 +79,22 @@ in
       set -x
 
       mkdir -p qubeized_images/nixos
-      ln -s ${rootImg}/nixos.img qubeized_images/nixos/root.img
+      ln -s ${rootImg} qubeized_images/nixos/root.img
 
       ln -s "appmenus_generic" appmenus
       cp template_generic.conf template.conf
 
-      date +"%Y%m%d%H%M" > build_timestamp_nixos
+      echo ${templateTimestamp} > build_timestamp_nixos
       echo ${qubesVersion} > version
 
       substituteInPlace templates.spec --replace qubeized_images "$(pwd)/qubeized_images"
       substituteInPlace templates.spec --replace " appmenus" " $(pwd)/appmenus"
       substituteInPlace templates.spec --replace " template.conf" " $(pwd)/template.conf"
+
+      substituteInPlace build_template_rpm --replace "rpmbuild --target" \
+        "rpmbuild --define 'build_mtime_policy clamp_to_source_date_epoch' --target"
+      substituteInPlace build_template_rpm --replace "rpmbuild --define" \
+        "rpmbuild --define 'use_source_date_epoch_as_buildtime 1' --define"
 
       DIST=nixos ./build_template_rpm nixos
     '';

--- a/tools/rpm.nix
+++ b/tools/rpm.nix
@@ -7,6 +7,7 @@
   qubesVersion,
   templateTimestamp ? "197001010000",
   dist ? "nixos",
+  rootSize ? "10G",
 }: let
   version = "4.0.6";
   toplevel = nixosConfig.config.system.build.toplevel;
@@ -53,7 +54,7 @@
     '';
   }).overrideAttrs (prev: {
     buildCommand = prev.buildCommand + ''
-      truncate -s 10G $img
+      truncate -s ${rootSize} $img
     '';
   });
 in
@@ -91,6 +92,10 @@ in
       substituteInPlace templates.spec --replace qubeized_images "$(pwd)/qubeized_images"
       substituteInPlace templates.spec --replace " appmenus" " $(pwd)/appmenus"
       substituteInPlace templates.spec --replace " template.conf" " $(pwd)/template.conf"
+
+      # https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression
+      # Exchanging a bit of compression for speed
+      substituteInPlace build_template_rpm --replace "w2.xzdio" "w10.zstdio"
 
       substituteInPlace build_template_rpm --replace "rpmbuild --target" \
         "rpmbuild --define 'build_mtime_policy clamp_to_source_date_epoch' --target"

--- a/tools/rpm.nix
+++ b/tools/rpm.nix
@@ -6,6 +6,7 @@
   nixosConfig,
   qubesVersion,
   templateTimestamp ? "197001010000",
+  dist ? "nixos",
 }: let
   version = "4.0.6";
   toplevel = nixosConfig.config.system.build.toplevel;
@@ -78,13 +79,13 @@ in
     buildPhase = ''
       set -x
 
-      mkdir -p qubeized_images/nixos
-      ln -s ${rootImg} qubeized_images/nixos/root.img
+      mkdir -p qubeized_images/${dist}
+      ln -s ${rootImg} qubeized_images/${dist}/root.img
 
       ln -s "appmenus_generic" appmenus
       cp template_generic.conf template.conf
 
-      echo ${templateTimestamp} > build_timestamp_nixos
+      echo ${templateTimestamp} > build_timestamp_${dist}
       echo ${qubesVersion} > version
 
       substituteInPlace templates.spec --replace qubeized_images "$(pwd)/qubeized_images"
@@ -96,7 +97,7 @@ in
       substituteInPlace build_template_rpm --replace "rpmbuild --define" \
         "rpmbuild --define 'use_source_date_epoch_as_buildtime 1' --define"
 
-      DIST=nixos ./build_template_rpm nixos
+      DIST=${dist} ./build_template_rpm ${dist}
     '';
 
     installPhase = ''


### PR DESCRIPTION
Hi ㋎ and thanks for your work on this! This is really nice and I've been trying to get this to work on Q4.3. I'm not there yet (currently having some `PYTHONPATH` issues for `etc/qubes-rpc/qubes.StartApp`) but I don't have a good dev setup on my Qubes machine so I don't have those changes in a repo yet. 

But what I did get around to first was trying to make the rpm fully reproducible. 2 things needed changing: RPM packaging itself needed to be instructed to do timestamp clamping (because their defaults are silly), and instead of creating a template with a boot partition etc using `make-disk-image.nix` (which as far as I could tell from its comments cannot create fully reproducible images), an ext4 file system with `make-ext4-fs.nix` works as well[^1]. That one does most things right already, the only thing that isn't reproducible is the `hash_seed` that gets set randomly when creating a file system - so that needs to be overridden manually[^2], plus the minimal steps to get NixOS to be normally functional also need to be added (because `make-ext4-fs.nix` is a more generic tool). This also truncates the image to the most minimal size, so we need to manually grow the file - no resize2fs call needed because Qubes will grow the root partition automatically to the size we specify there.  

  [^1]: Qubes really doesn't care much about the format of how a VM is set up, but I suspect this also makes it PVH only
  [^2]: I'd prefer the UUID to be generated from the timestamp but couldn't find anything in nixpkgs that would help me with that so I left it for another day and used the example from reproducible-builds.org - AFAIK it isn't a security relevant field anyway.

The rest are just conveniences I added (also because I want to use `rpm.nix` from my own flakes that set up different images)

<details><summary>This is a minimal patch for the current state of the repository. To get this to build on my setup I also had to change these two lines, not sure though if that's a me thing or a general issue.</summary>

```diff
diff --git a/flake.nix b/flake.nix
index f0047c9..799e835 100644
--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,5 @@
       templateTimestamp = builtins.substring 0 12 self.lastModifiedDate;
     };
     iso = nixosConfigurations.iso.config.system.build.isoImage;
-    packages.x86_64-linux = pkgs;
   };
 }
diff --git a/pkgs/qubes-core-agent-linux/generic.nix b/pkgs/qubes-core-agent-linux/generic.nix
index 197d635..f579626 100644
--- a/pkgs/qubes-core-agent-linux/generic.nix
+++ b/pkgs/qubes-core-agent-linux/generic.nix
@@ -417,7 +417,7 @@ in
             "cannot:bin/qubes-vmexec"
             "cannot:lib/qubes/init/bind-dirs.sh"
             "cannot:lib/qubes/qfile-unpacker"
-            "cannot:${qubes-core-qrexec}/bin/qrexec-client-vm"
+            "cannot:${qubes-core-qrexec}/lib/qubes/qrexec-client-vm"
             "cannot:${zenity}/bin/zenity"
           ]
           ++ lib.optional enableNetworking "cannot:${iproute2}/bin/ip";
```
</details>

Happy to answer questions or change things! Cheers