### PR TITLE
fix: local rpm build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,28 @@
       nixosConfig = nixosConfigurations.nixos;
     };
     iso = nixosConfigurations.iso.config.system.build.isoImage;
-    packages.x86_64-linux = pkgs;
+
+    # Expose only the custom qubes packages (not all of nixpkgs) so that
+    # `nix build .#rpm` resolves to the template RPM above rather than being
+    # shadowed by `pkgs.rpm` within nixpkgs.
+    #
+    # The `update.sh` script uses `nix-update` to target patching.
+    packages.x86_64-linux = {
+      inherit
+        (pkgs)
+        qubes-core-qubesdb
+        qubes-core-vchan-xen
+        qubes-core-qrexec
+        qubes-core-agent-linux
+        qubes-linux-utils
+        qubes-gui-common
+        qubes-gui-agent-linux
+        qubes-sshd
+        qubes-usb-proxy
+        qubes-gpg-split
+        nix-update
+        ;
+      inherit rpm iso;
+    };
   };
 }

--- a/pkgs/qubes-core-agent-linux/generic.nix
+++ b/pkgs/qubes-core-agent-linux/generic.nix
@@ -417,7 +417,7 @@ in
             "cannot:bin/qubes-vmexec"
             "cannot:lib/qubes/init/bind-dirs.sh"
             "cannot:lib/qubes/qfile-unpacker"
-            "cannot:${qubes-core-qrexec}/bin/qrexec-client-vm"
+            "cannot:${qubes-core-qrexec}/lib/qubes/qrexec-client-vm"
             "cannot:${zenity}/bin/zenity"
           ]
           ++ lib.optional enableNetworking "cannot:${iproute2}/bin/ip";

--- a/pkgs/qubes-gui-agent-linux/generic.nix
+++ b/pkgs/qubes-gui-agent-linux/generic.nix
@@ -31,7 +31,8 @@
   util-linux,
   which,
   xen,
-  xfce,
+  xfce4-settings,
+  xfconf,
   xorg,
   zenity,
   version,
@@ -86,7 +87,7 @@ resholve.mkDerivation rec {
       zenity
       python3Packages.xcffib
       systemd
-      xfce.xfconf
+      xfconf
       # xdg-user-dirs-update
     ]
     ++ (with xorg; [
@@ -207,8 +208,8 @@ resholve.mkDerivation rec {
         systemd
         util-linux
         which
-        xfce.xfce4-settings
-        xfce.xfconf
+        xfce4-settings
+        xfconf
         xorg.xprop
         xorg.xinit
         xorg.xsetroot
@@ -223,8 +224,8 @@ resholve.mkDerivation rec {
       };
       execer = [
         "cannot:${systemd}/bin/systemctl"
-        "cannot:${xfce.xfce4-settings}/bin/xfsettingsd"
-        "cannot:${xfce.xfconf}/bin/xfconf-query"
+        "cannot:${xfce4-settings}/bin/xfsettingsd"
+        "cannot:${xfconf}/bin/xfconf-query"
         # lies
         "cannot:bin/qubes-gui-runuser"
         "cannot:${util-linux}/bin/runuser"


### PR DESCRIPTION
The "packages" masking was causing the build to fail silently.

      ❯ nix build .#rpm && ls -ls ./result/
      total 0
      0 dr-xr-xr-x 1 root root 202 Dec 31  1969 bin
      0 dr-xr-xr-x 1 root root 410 Dec 31  1969 lib
      0 dr-xr-xr-x 1 root root  18 Dec 31  1969 share

There was also a "result-man" symlink in the top-level, which shouldn't be there.

The change to the resholve config for the qubes-core-agent-linux was necessary due to recent upstream changes, to match paths in the Qubes-maintained package.

As soon as the RPM build worked, I saw warnings about the xfce packages:

    evaluation warning: ‘xfce.xfce4-settings’ was moved to top-level. Please use ‘pkgs.xfce4-settings’ directly
    evaluation warning: ‘xfce.xfconf’ was moved to top-level. Please use ‘pkgs.xfconf’ directly
    evaluation warning: ‘xfce.xfconf’ was moved to top-level. Please use ‘pkgs.xfconf’ directly
    evaluation warning: ‘xfce.xfce4-settings’ was moved to top-level. Please use ‘pkgs.xfce4-settings’ directly
    evaluation warning: ‘xfce.xfconf’ was moved to top-level. Please use ‘pkgs.xfconf’ directly

So the xfce package references have been revised accordingly. 

Closes #10.