### PR TITLE
Migrate template from Qubes 4.2 -> 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ without gpg signature verification
 1. download the template rpm from github releases or build it yourself via `nix build .#rpm` ( preferred )
 2. copy the template rpm to dom0
 ```
-qvm-run --pass-io <YOUR_DOWNLOAD_VM> 'cat <FULL_RPM_PATH>' > qubes-template-nixos-4.2.0-unavailable.noarch.rpm
+qvm-run --pass-io <YOUR_DOWNLOAD_VM> 'cat <FULL_RPM_PATH>' > qubes-template-nixos-4.3.0-unavailable.noarch.rpm
 ```
 3. install the template
 ```
-qvm-template install qubes-template-nixos-4.2.0-unavailable.noarch.rpm --nogpgcheck
+qvm-template install qubes-template-nixos-4.3.0-unavailable.noarch.rpm --nogpgcheck
 ```
 4. start the template and wait about 30s ( see qrexec notes. )
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,28 @@
       nixosConfig = nixosConfigurations.nixos;
     };
     iso = nixosConfigurations.iso.config.system.build.isoImage;
-    packages.x86_64-linux = pkgs;
+
+    # Expose only the custom qubes packages (not all of nixpkgs) so that
+    # `nix build .#rpm` resolves to the template RPM above rather than being
+    # shadowed by `pkgs.rpm` within nixpkgs.
+    #
+    # The `update.sh` script uses `nix-update` to target patching.
+    packages.x86_64-linux = {
+      inherit
+        (pkgs)
+        qubes-core-qubesdb
+        qubes-core-vchan-xen
+        qubes-core-qrexec
+        qubes-core-agent-linux
+        qubes-linux-utils
+        qubes-gui-common
+        qubes-gui-agent-linux
+        qubes-sshd
+        qubes-usb-proxy
+        qubes-gpg-split
+        nix-update
+        ;
+      inherit rpm iso;
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,7 @@
     };
     rpm = pkgs.callPackage ./tools/rpm.nix {
       inherit nixpkgs;
-      qubesVersion = "4.2.0";
+      qubesVersion = "4.3.0";
       nixosConfig = nixosConfigurations.nixos;
     };
     iso = nixosConfigurations.iso.config.system.build.isoImage;

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+# run linting checks against repo
+lint:
+  nix flake check --all-systems
+
+alias check := lint
+
+# build template rpm via nix flake
+build:
+  nix build .#rpm
+  # built rpm available at:
+  find result/ -type f -iname '*.rpm'
+
+alias rpm := build

--- a/pkgs/qubes-core-agent-linux/default.nix
+++ b/pkgs/qubes-core-agent-linux/default.nix
@@ -3,7 +3,7 @@
   enableNetworking ? false,
 }:
 callPackage ./generic.nix {
-  version = "4.3.40";
-  hash = "sha256-QT3DNX2lh1vTmfgGK6kXDLFqtImFc4zVKsofCUIPvXs=";
+  version = "4.3.45";
+  hash = "sha256-cdqGWw/ock12VVUCbIFNDMV8NxNtHuW+9SzX6T6oZIk=";
   inherit enableNetworking;
 }

--- a/pkgs/qubes-core-agent-linux/default.nix
+++ b/pkgs/qubes-core-agent-linux/default.nix
@@ -3,7 +3,7 @@
   enableNetworking ? false,
 }:
 callPackage ./generic.nix {
-  version = "4.2.45";
-  hash = "sha256-Eb7ueu1EVnVgudY98od4nsYjxi0jynsbwYXglL7tynA=";
+  version = "4.3.40";
+  hash = "sha256-QT3DNX2lh1vTmfgGK6kXDLFqtImFc4zVKsofCUIPvXs=";
   inherit enableNetworking;
 }

--- a/pkgs/qubes-core-agent-linux/generic.nix
+++ b/pkgs/qubes-core-agent-linux/generic.nix
@@ -157,6 +157,11 @@ in
 
       # skip installing qfile-unpacker / bin-qfile-unpacker as SUID
       sed -i 's/-m 4755/-m 755/g' qubes-rpc/Makefile
+
+      # 4.3 unified qvm-{copy,move}{,-to-vm} into one qvm-copy script (others
+      # become hardlinks at install time) and made paths relative via $scriptdir.
+      # Rewrite back to absolute paths so the existing resholve fix entries match.
+      sed -i 's#"\$scriptdir/qubes/#"/usr/lib/qubes/#g' qubes-rpc/qvm-copy
     '';
 
     buildPhase = ''
@@ -401,6 +406,9 @@ in
         keep = {
           source = ["$file_name"];
           "$rc" = true;
+          # 4.3 mount-dirs.sh uses these as bool-flag commands (`if $mount_home; then`)
+          "$mount_home" = true;
+          "$mount_usr_local" = true;
           "/rw/config/qubes_ip_change_hook" = enableNetworking;
           "/rw/config/qubes-ip-change-hook" = enableNetworking;
           "/run/wrappers/bin/qfile-unpacker" = true;
@@ -418,6 +426,7 @@ in
             "cannot:lib/qubes/init/bind-dirs.sh"
             "cannot:lib/qubes/qfile-unpacker"
             "cannot:${qubes-core-qrexec}/lib/qubes/qrexec-client-vm"
+            "cannot:${qubes-core-qrexec}/bin/qrexec-client-vm"
             "cannot:${zenity}/bin/zenity"
           ]
           ++ lib.optional enableNetworking "cannot:${iproute2}/bin/ip";

--- a/pkgs/qubes-core-agent-linux/generic.nix
+++ b/pkgs/qubes-core-agent-linux/generic.nix
@@ -417,7 +417,7 @@ in
             "cannot:bin/qubes-vmexec"
             "cannot:lib/qubes/init/bind-dirs.sh"
             "cannot:lib/qubes/qfile-unpacker"
-            "cannot:${qubes-core-qrexec}/bin/qrexec-client-vm"
+            "cannot:${qubes-core-qrexec}/lib/qubes/qrexec-client-vm"
             "cannot:${zenity}/bin/zenity"
           ]
           ++ lib.optional enableNetworking "cannot:${iproute2}/bin/ip";

--- a/pkgs/qubes-core-qrexec/default.nix
+++ b/pkgs/qubes-core-qrexec/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.2.25";
-  hash = "sha256-+iS13bwyi/C79pgjwEaJUGFtb+Z2y47y720wpnVfE20=";
+  version = "4.3.12";
+  hash = "sha256-pG3tVc4AFYYu/7d4a1sfiGkSIu7cVp/YPW1oqcsgf9E=";
 }

--- a/pkgs/qubes-core-qubesdb/default.nix
+++ b/pkgs/qubes-core-qubesdb/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.3.2";
-  hash = "sha256-zbvMfNmHrQvopAz2Zu859i/7US0Ug4YHAlNmRxwVVM0=";
+  version = "4.3.3";
+  hash = "sha256-KKuEt+X3L4H3HVAkJru9fxKa05xuxlcex+uQWPpBPVw=";
 }

--- a/pkgs/qubes-core-qubesdb/default.nix
+++ b/pkgs/qubes-core-qubesdb/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.2.10";
-  hash = "sha256-K0fIss07FfDpYxlrecc4lbNMmEK30T2C2Sg8qSuLxYo=";
+  version = "4.3.2";
+  hash = "sha256-zbvMfNmHrQvopAz2Zu859i/7US0Ug4YHAlNmRxwVVM0=";
 }

--- a/pkgs/qubes-gui-agent-linux/default.nix
+++ b/pkgs/qubes-gui-agent-linux/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.3.15";
-  hash = "sha256-6DWsJRZkogeQRhSM9S6YyKxsv/jTzwXLjzrZsuBhRT4=";
+  version = "4.3.17";
+  hash = "sha256-zFbaVnQK8m1NdAClcxGZ2/FmI00huHEmXejOksLCy7s=";
 }

--- a/pkgs/qubes-gui-agent-linux/default.nix
+++ b/pkgs/qubes-gui-agent-linux/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.2.22";
-  hash = "sha256-vpVSA8JkoppllqhXOCkareg1HknHaRwbI6sDb4p/2Eg=";
+  version = "4.3.15";
+  hash = "sha256-6DWsJRZkogeQRhSM9S6YyKxsv/jTzwXLjzrZsuBhRT4=";
 }

--- a/pkgs/qubes-gui-agent-linux/generic.nix
+++ b/pkgs/qubes-gui-agent-linux/generic.nix
@@ -31,7 +31,8 @@
   util-linux,
   which,
   xen,
-  xfce,
+  xfce4-settings,
+  xfconf,
   xorg,
   zenity,
   version,
@@ -86,7 +87,7 @@ resholve.mkDerivation rec {
       zenity
       python3Packages.xcffib
       systemd
-      xfce.xfconf
+      xfconf
       # xdg-user-dirs-update
     ]
     ++ (with xorg; [
@@ -207,8 +208,8 @@ resholve.mkDerivation rec {
         systemd
         util-linux
         which
-        xfce.xfce4-settings
-        xfce.xfconf
+        xfce4-settings
+        xfconf
         xorg.xprop
         xorg.xinit
         xorg.xsetroot
@@ -223,8 +224,8 @@ resholve.mkDerivation rec {
       };
       execer = [
         "cannot:${systemd}/bin/systemctl"
-        "cannot:${xfce.xfce4-settings}/bin/xfsettingsd"
-        "cannot:${xfce.xfconf}/bin/xfconf-query"
+        "cannot:${xfce4-settings}/bin/xfsettingsd"
+        "cannot:${xfconf}/bin/xfconf-query"
         # lies
         "cannot:bin/qubes-gui-runuser"
         "cannot:${util-linux}/bin/runuser"

--- a/pkgs/qubes-gui-agent-linux/generic.nix
+++ b/pkgs/qubes-gui-agent-linux/generic.nix
@@ -15,6 +15,7 @@
   git,
   gnused,
   libgbm,
+  libunistring,
   pam,
   patch,
   pipewire,
@@ -83,6 +84,7 @@ resholve.mkDerivation rec {
       coreutils
       qubes-core-vchan-xen
       qubes-core-qubesdb
+      libunistring
       pam
       zenity
       python3Packages.xcffib

--- a/pkgs/qubes-gui-common/default.nix
+++ b/pkgs/qubes-gui-common/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.2.5";
-  hash = "sha256-rv80X/wecXRtJ3HhHgksJd43AKvLQTHyX8e1EJPwEO0=";
+  version = "4.3.1";
+  hash = "sha256-RDB2tS+vLXu7RwA6Ng4TekIubzIKtuQK8ALRGjsXmcY=";
 }

--- a/pkgs/qubes-linux-utils/default.nix
+++ b/pkgs/qubes-linux-utils/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.2.22";
-  hash = "sha256-6fZKDh2BuJcF4BeyHgeLNUHBL6TP5JDrV/+ghRrw/WI=";
+  version = "4.3.17";
+  hash = "sha256-psDPQCzburVJ/RmMx9XI09cf+A223pr4K6hs8l+KAqc=";
 }

--- a/pkgs/qubes-usb-proxy/default.nix
+++ b/pkgs/qubes-usb-proxy/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "4.3.5";
-  hash = "sha256-ieN+GtDmlL4cARnFcM3dVsjNKeH1ZuXUElTj2Tu3H+w=";
+  version = "4.3.6";
+  hash = "sha256-MjM4rbYzPpp47KRJXbyptogIvm5xxCqktifePmqVZX8=";
 }

--- a/pkgs/qubes-usb-proxy/default.nix
+++ b/pkgs/qubes-usb-proxy/default.nix
@@ -1,5 +1,5 @@
 {callPackage}:
 callPackage ./generic.nix {
-  version = "1.3.3";
-  hash = "sha256-aFpFZs11IdWYl6PYAfpAjvosw9lxvyzW5BR/6DXv2Y4=";
+  version = "4.3.5";
+  hash = "sha256-ieN+GtDmlL4cARnFcM3dVsjNKeH1ZuXUElTj2Tu3H+w=";
 }

--- a/update.sh
+++ b/update.sh
@@ -20,24 +20,24 @@ update_packages() {
   done
 }
 
+# qubes-core-vchan-xen has no 4.3 tag yet; the 4.2 line still builds against Xen 4.19
 update_packages "v(4\.2\.[0-9.]+)" "" \
+  "pkgs/qubes-core-vchan-xen"
+
+update_packages "v(4\.3\.[0-9.]+)" "" \
   "pkgs/qubes-core-qubesdb" \
-  "pkgs/qubes-core-vchan-xen" \
   "pkgs/qubes-gui-common"
 
 # whenever we use resholve, we need to look at the original derivation to find the updatable url
-update_packages "v(4\.2\.[0-9.]+)" ".src" \
+update_packages "v(4\.3\.[0-9.]+)" ".src" \
   "pkgs/qubes-core-agent-linux" \
   "pkgs/qubes-core-qrexec" \
-  "pkgs/qubes-gui-agent-linux"
+  "pkgs/qubes-gui-agent-linux" \
+  "pkgs/qubes-usb-proxy"
 
 # in one case we wrap the resholved package
-update_packages "v(4\.2\.[0-9.]+)" ".src.src" \
+update_packages "v(4\.3\.[0-9.]+)" ".src.src" \
   "pkgs/qubes-linux-utils"
-
-# this is an odd case as 1.3 is the release line for 4.2
-update_packages "v(1\.3\.[0-9.]+)" ".src" \
-  "pkgs/qubes-usb-proxy"
 
 # these packages should work for both 4.2 and 4.3
 update_packages "v([0-9.]+)" ".src" \


### PR DESCRIPTION
Closes #9. 

Updates all the Qubes packages to follow 4.3, rather than 4.2, channels, as 4.2 is approaching EOL [0]. In terms of functionality testing, I've confirmed the following on a live 4.3 machine:

- [x] RPM builds for 4.3
- [x] RPM installs in dom0 4.3
- [x] can create an AppVM based off "nixos" template
- [x] can boot an AppVM based off "nixos" template
- [x] can run a terminal in an AppVM based off "nixos" template
- [x] can curl URL in AppVM based off "nixos" template

There may be errors lingering, but this feels like a good baseline for the migration.

[0] https://www.qubes-os.org/news/2026/04/27/qubes-os-4-2-approaching-end-of-life/

## Testing and review

This PR depends on https://github.com/evq/qubes-nixos-template/pull/11, so that should be reviewed and merged first. 